### PR TITLE
A small tweak to help cooperation with @anywhere

### DIFF
--- a/chrome_extension/hover_script.js
+++ b/chrome_extension/hover_script.js
@@ -202,7 +202,8 @@ $(document).ready(function() {
 		deactive_tiptip();
 	});
 	
-	$("a").live('mouseover mouseout', function(event) {
+	// Ignore links which already show a Twitter @anywhere popup on mouseover
+	$("a:not(.twitter-anywhere-user)").live('mouseover mouseout', function(event) {
 		// on mouseover
 		if (event.type == 'mouseover') {
 			var control = $(this);

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "LinkPeelr",
-	"version": "1.6",
+	"version": "1.6.1",
 	"description": "Know Where Link Is Going Before You Click",
 	
 	"icons": {


### PR DESCRIPTION
Hi,

I've been working with the [Twitter @anywhere API](http://dev.twitter.com/anywhere) and I noticed that LinkPeelr sometimes conflicts with the  hovercards that appear when you hover over a Twitter username. Take a look [here](http://www.campaignmonitor.com/meet-the-team/) and hover over someone's Twitter name with LinkPeelr enabled to see what I mean.

I've made a small change to the hover script to omit these links (they are always just links to the user's Twitter profile anyway).

Kind regards,
Mark B
